### PR TITLE
docs: fix simple typo, througout -> throughout

### DIFF
--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -10,7 +10,7 @@ import warnings
 
 # Global setup function. Download DBs if missing.
 def my_setup():
-    # Set fake environmental variables, tests this functionality implicitly througout
+    # Set fake environmental variables, tests this functionality implicitly throughout
     setup_demo_env()
     if not os.path.exists(os.environ.get("QUERY_DB_NAME")):
         raise Exception("Necessary Chinook SQLite test database not found.")


### PR DESCRIPTION
There is a small typo in tests/core_test.py.

Should read `throughout` rather than `througout`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md